### PR TITLE
Add support for the ‘ghcSyntaxHighlighter’ extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## MMark CLI 0.0.5.0
+
+* Added support for the `ghcSyntaxHighlighter` extension. Only available
+  when compiled with GHC >= 8.4.1.
+
 ## MMark CLI 0.0.4.0
 
 * This version works with `mmark-0.0.6.0` and `megaparsec-7.0.0`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   * [MathJax](#mathjax)
   * [Email obfuscation](#email-obfuscation)
   * [Punctuation prettifier](#punctuation-prettifier)
+  * [GHC syntax highlighter](#ghc-syntax-highlighter)
   * [Skylighting](#skylighting)
   * [Table of contents](#table-of-contents)
 * [Contribution](#contribution)
@@ -283,6 +284,36 @@ Something---we don't know what, happened...
 <p>Something—we don’t know what, happened…</p>
 ```
 
+### GHC syntax highlighter
+
+* Option: `--ext-ghc-highlighter`
+
+Use the [GHC syntax
+highlighter](https://hackage.haskell.org/package/ghc-syntax-highlighter)
+package to highlight code blocks with `"haskell"` info string using lexer of
+GHC itself.
+
+The resulting HTML will be rendered as described
+[here](https://hackage.haskell.org/package/mmark-ext/docs/Text-MMark-Extension-GhcSyntaxHighlighter.html#v:ghcSyntaxHighlighter).
+
+Example:
+
+````
+[mark@arch ~]$ mmark --ext-skylighting
+Some Haskell:
+
+```haskell
+main :: IO ()
+main = return ()
+```
+----------------------- Control-D
+<p>Some Haskell:</p>
+<div class="source-code"><pre><code class="language-haskell">
+<span class="va">main</span><span> </span><span class="sy">::</span><span> </span><span class="cr">IO</span><span> </span><span class="sy">(</span><span class="sy">)</span><span>
+</span><span class="va">main</span><span> </span><span class="sy">=</span><span> </span><span class="va">return</span><span> </span><span class="sy">(</span><span class="sy">)</span><span>
+</span></code></pre></div>
+````
+
 ### Skylighting
 
 * Option: `--ext-skylighting`
@@ -292,7 +323,7 @@ package to render code blocks with info strings that result in a successful
 lookup from the syntax table that comes with the library.
 
 The resulting HTML will be rendered as described
-[here](https://hackage.haskell.org/package/mmark-ext-0.2.0.0/docs/Text-MMark-Extension-Skylighting.html#v:skylighting).
+[here](https://hackage.haskell.org/package/mmark-ext/docs/Text-MMark-Extension-Skylighting.html#v:skylighting).
 
 Example:
 
@@ -367,7 +398,7 @@ Baz.
 Issues, bugs, and questions may be reported in [the GitHub issue tracker for
 this project](https://github.com/mmark-md/mmark-cli/issues).
 
-Pull requests are also welcome and will be reviewed quickly.
+Pull requests are also welcome.
 
 ## License
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -61,6 +61,9 @@ main = do
             , f optExtMathJax               (Ext.mathJax (Just '$'))
             , g optExtObfuscateEmail        Ext.obfuscateEmail
             , f optExtPunctuationPrettifier Ext.punctuationPrettifier
+#if __GLASGOW_HASKELL__ >= 804
+            , f optExtGhcSyntaxHighlighter  Ext.ghcSyntaxHighlighter
+#endif
             , f optExtSkylighting           Ext.skylighting
             , g optExtToc $ \(from,to) ->
                Ext.toc "toc" . MMark.runScanner doc . Ext.tocScanner $ \x ->
@@ -119,6 +122,10 @@ data Opts = Opts
     -- ^ Enable extension: 'Ext.obfuscateEmail'
   , optExtPunctuationPrettifier :: !Bool
     -- ^ Enable extension: 'Ext.punctuationPrettifier'
+#if __GLASGOW_HASKELL__ >= 804
+  , optExtGhcSyntaxHighlighter :: !Bool
+    -- ^ Enable extension: 'Ext.ghcSyntaxHighlighter'
+#endif
   , optExtSkylighting :: !Bool
     -- ^ Enable extension: 'Ext.skylighting'
   , optExtToc :: !(Maybe (Int, Int))
@@ -208,6 +215,12 @@ optsParser = Opts
     [ long    "ext-punctuation"
     , help    "Enable punctuation prettifier"
     ]
+#if __GLASGOW_HASKELL__ >= 804
+  <*> (switch . mconcat)
+    [ long    "ext-ghc-highlighter"
+    , help    "Enable GHC syntax highlighter for Haskell code"
+    ]
+#endif
   <*> (switch . mconcat)
     [ long    "ext-skylighting"
     , help    "Enable syntax highlighting of code snippets with Skylighting"

--- a/mmark-cli.cabal
+++ b/mmark-cli.cabal
@@ -41,6 +41,8 @@ executable mmark
                     , text             >= 0.2   && < 1.3
                     , unordered-containers >= 0.2.5 && < 0.3
   other-modules:      Paths_mmark_cli
+  if impl(ghc >= 8.4)
+    build-depends:    ghc-syntax-highlighter >= 0.0.1 && < 0.1
   if flag(dev)
     ghc-options:      -Wall -Werror -Wcompat
                       -Wincomplete-record-updates


### PR DESCRIPTION
Available conditionally, only with GHC >= 8.4.1.